### PR TITLE
chore: update slab to 0.4.11 to fix security vulnerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1204,9 +1204,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"


### PR DESCRIPTION
- Fix RUSTSEC-2025-0047: out-of-bounds access in slab
- Update transitive dependency from 0.4.10 to 0.4.11
- No breaking changes, all tests passing"