### PR TITLE
chore: fix daily CI failures (security audit + flaky cache test)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1137,9 +1137,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -1352,9 +1352,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/domain-check-lib/src/protocols/registry.rs
+++ b/domain-check-lib/src/protocols/registry.rs
@@ -648,6 +648,16 @@ pub fn get_bootstrap_cache_stats() -> Result<(usize, bool), DomainCheckError> {
 mod tests {
     use super::*;
 
+    // Serializes tests that touch the global bootstrap cache so parallel
+    // execution doesn't let one test's `clear_bootstrap_cache()` wipe another
+    // test's freshly cached entry before its assertion runs.
+    fn cache_test_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+    }
+
     // ── extract_tld ─────────────────────────────────────────────────────
 
     #[test]
@@ -794,6 +804,7 @@ mod tests {
 
     #[test]
     fn test_whois_server_caching() {
+        let _guard = cache_test_lock();
         clear_bootstrap_cache().unwrap();
 
         cache_whois_server("com", "whois.verisign-grs.com").unwrap();
@@ -807,6 +818,7 @@ mod tests {
 
     #[test]
     fn test_whois_negative_caching() {
+        let _guard = cache_test_lock();
         clear_bootstrap_cache().unwrap();
 
         cache_whois_server("fake", "").unwrap();
@@ -818,6 +830,7 @@ mod tests {
 
     #[test]
     fn test_whois_cache_case_insensitive() {
+        let _guard = cache_test_lock();
         clear_bootstrap_cache().unwrap();
 
         cache_whois_server("COM", "whois.verisign-grs.com").unwrap();
@@ -831,6 +844,7 @@ mod tests {
 
     #[test]
     fn test_whois_not_negatively_cached_when_absent() {
+        let _guard = cache_test_lock();
         clear_bootstrap_cache().unwrap();
         assert!(!is_whois_negatively_cached("neverqueried"));
         clear_bootstrap_cache().unwrap();
@@ -840,6 +854,7 @@ mod tests {
 
     #[test]
     fn test_clear_bootstrap_cache() {
+        let _guard = cache_test_lock();
         // Populate some data
         cache_whois_server("test", "whois.test.com").unwrap();
         clear_bootstrap_cache().unwrap();
@@ -850,6 +865,7 @@ mod tests {
 
     #[test]
     fn test_get_bootstrap_cache_stats() {
+        let _guard = cache_test_lock();
         clear_bootstrap_cache().unwrap();
         let (count, stale) = get_bootstrap_cache_stats().unwrap();
         assert_eq!(count, 0);


### PR DESCRIPTION
## Summary

Fixes the daily scheduled CI failures on `main`. Three issues addressed:

### 1. Security audit — `rustls-webpki` vulnerabilities (3)
- `rustls-webpki` 0.103.10 → 0.103.13 clears:
  - **RUSTSEC-2026-0104** — reachable panic in CRL parsing
  - **RUSTSEC-2026-0099** — name constraints accepted for wildcard certs
  - **RUSTSEC-2026-0098** — name constraints for URI names incorrectly accepted
- Transitive via reqwest → tokio-rustls / hyper-rustls. Semver-compatible patch bump — `Cargo.lock` only.

### 2. Security audit — `rand` unsound warning
- `rand` 0.9.2 → 0.9.4 clears **RUSTSEC-2026-0097** (unsound with custom logger using `rand::rng()`). Transitive via quinn-proto.

### 3. Flaky test on beta / 1.88.0 — `test_whois_cache_case_insensitive`
Root cause: six tests in `protocols::registry::tests` share a global `static OnceLock<Mutex<BootstrapCache>>` and each call `clear_bootstrap_cache()`. Cargo runs tests in parallel, so one test's clear could wipe another's just-cached entry between `cache_whois_server(...)` and the `get_cached_whois_server(...)` assertion — a classic race that surfaces inconsistently across toolchains.

Fix: added a test-local `cache_test_lock()` helper (static `Mutex<()>`, poison-tolerant) and acquire it at the top of each of the six cache-touching tests. Serializes only the affected tests; everything else still runs in parallel.

## Test plan

- [x] `cargo audit` — clean (0 vulnerabilities, 0 warnings)
- [x] `cargo test --workspace` — 419 passed, 0 failed
- [x] Ran `cargo test -p domain-check-lib --lib protocols::registry::tests` 5× back-to-back — no flake
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings -A clippy::uninlined_format_args` — clean
- [x] `cargo fmt --all --check` — clean
- [ ] CI green on this PR (incl. beta + 1.88.0 matrix)